### PR TITLE
Fix where packages point to in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 
-from setuptools import find_packages, setup
+from setuptools import setup
 
 with open("README.md", "r", encoding="utf-8") as f:
     long_description = f.read()
@@ -10,7 +10,7 @@ setup(
     version="2021.7.0",
     description="Dask + Mongo intergration",
     license="BSD",
-    packages=find_packages(where="dask-mongo"),
+    packages=["dask_mongo"],
     long_description=long_description,
     long_description_content_type="text/markdown",
     python_requires=">=3.7",


### PR DESCRIPTION
In `setup.py` the line `packages=find_packages(where="dask-mongo")` is returning an empty list. 
Replaced for `packages=["dask_mongo"]`