### PR TITLE
Import `loop_in_thread` fixture in tests

### DIFF
--- a/dask_mongo/tests/test_core.py
+++ b/dask_mongo/tests/test_core.py
@@ -7,7 +7,8 @@ import pymongo
 import pytest
 from dask.bag.utils import assert_eq
 from distributed.utils_test import cluster_fixture  # noqa: F401
-from distributed.utils_test import client, gen_cluster, loop  # noqa: F401
+from distributed.utils_test import gen_cluster  # noqa: F401
+from distributed.utils_test import cleanup, client, loop, loop_in_thread  # noqa: F401
 
 from dask_mongo import read_mongo, to_mongo
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -2,3 +2,6 @@
 exclude = __init__.py
 max-line-length = 120
 ignore = F811
+
+[isort]
+profile = black


### PR DESCRIPTION
Similar to https://github.com/dask/dask/pull/9337. Should fix CI failures we're seeing. 